### PR TITLE
Add conversation style parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sydney.py
 
-[![Latest Release](https://img.shields.io/github/v/release/vsakkas/sydney.py.svg)](https://github.com/vsakkas/sydney.py/releases/tag/v0.4.0)
+[![Latest Release](https://img.shields.io/github/v/release/vsakkas/sydney.py.svg)](https://github.com/vsakkas/sydney.py/releases/tag/v0.5.0)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/vsakkas/sydney.py/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ from sydney import SydneyClient
 async def main() -> None:
     sydney = SydneyClient()
 
-    await sydney.start_conversation()
+    await sydney.start_conversation(style="balanced")
 
     response = await sydney.ask("Hello, how are you?")
     print(response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sydney-py"
-version = "0.4.0"
+version = "0.5.0"
 description = ""
 authors = ["vsakkas <vasileios.sakkas96@gmail.com>"]
 license = "MIT"

--- a/sydney/sydney.py
+++ b/sydney/sydney.py
@@ -1,5 +1,6 @@
 import json
 import os
+from enum import Enum
 
 import websockets.client as websockets
 from aiohttp import ClientSession
@@ -25,17 +26,41 @@ def as_json(message: dict) -> str:
     return json.dumps(message) + RECORD_SEPARATOR
 
 
+class ConversationStyle(Enum):
+    """
+    Bing Chat conversation styles. Supported options are:
+    - `creative` for original and imaginative chat
+    - `balanced` for informative and friendly chat
+    - `precise` for concise and straightforward chat
+    """
+
+    creative = "h3relaxedimg"
+    balanced = "galileo"
+    precise = "h3precise"
+
+
 class SydneyClient:
     def __init__(self) -> None:
-        self.conversation_id = None
-        self.client_id = None
-        self.conversation_signature = None
-        self.invocation_id = None
+        self.conversation_id: str = None
+        self.client_id: str = None
+        self.conversation_signature: str = None
+        self.invocation_id: str = None
+        self.conversation_style: ConversationStyle = None
         self.wss_client = None
 
-    async def start_conversation(self) -> None:
+    async def start_conversation(self, style: str = "balanced") -> None:
         """
         Connect to Bing Chat and create a new conversation.
+
+        Parameters
+        ----------
+        style : str
+            The conversatin style that Bing Chat will adopt. Supported options are:
+            - `creative` for original and imaginative chat
+            - `balanced` for informative and friendly chat
+            - `precise` for concise and straightforward chat
+
+            Default is "balanced".
         """
         # Use _U cookie to create a conversation.
         cookies = {"_U": os.environ["BING_U_COOKIE"]}
@@ -57,6 +82,7 @@ class SydneyClient:
             self.client_id = response_dict["clientId"]
             self.conversation_signature = response_dict["conversationSignature"]
             self.invocation_id = 0
+            self.conversation_style = getattr(ConversationStyle, style)
 
         await session.close()
 
@@ -89,8 +115,6 @@ class SydneyClient:
         )
         await self.wss_client.send(as_json({"protocol": "json", "version": 1}))
         await self.wss_client.recv()
-        await self.wss_client.send(as_json({"type": 6}))
-        await self.wss_client.recv()
 
         request = {
             "arguments": [
@@ -103,6 +127,7 @@ class SydneyClient:
                         "disable_emoji_spoken_text",
                         "responsible_ai_policy_235",
                         "enablemm",
+                        self.conversation_style.value,
                     ],
                     "isStartOfSession": self.invocation_id == 0,
                     "message": {
@@ -161,3 +186,4 @@ class SydneyClient:
         self.client_id = None
         self.conversation_signature = None
         self.invocation_id = None
+        self.conversation_style = None


### PR DESCRIPTION
- Add support for Bing Chat conversation styles. Supported options are:
    - `creative` for original and imaginative chat
    - `balanced` for informative and friendly chat
    - `precise` for concise and straightforward chat