### PR TITLE
Add Compose feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sydney.py
 
-[![Latest Release](https://img.shields.io/github/v/release/vsakkas/sydney.py.svg)](https://github.com/vsakkas/sydney.py/releases/tag/v0.7.0)
+[![Latest Release](https://img.shields.io/github/v/release/vsakkas/sydney.py.svg)](https://github.com/vsakkas/sydney.py/releases/tag/v0.8.0)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/vsakkas/sydney.py/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+The Sydney Client also supports the Compose feature:
+
+```python
+import asyncio
+
+from sydney import SydneyClient
+
+
+async def main() -> None:
+    sydney = SydneyClient()
+
+    await sydney.start_conversation()
+
+    response = await sydney.compose("Why Python is a great language", format="ideas")
+    print(response)
+
+    await sydney.close_conversation()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+For more detailed documentation and options, please refer to the code docstrings.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/vsakkas/sydney.py/blob/master/LICENSE) file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sydney-py"
-version = "0.7.0"
+version = "0.8.0"
 description = "Python Client for Bing Chat, also known as Sydney."
 authors = ["vsakkas <vasileios.sakkas96@gmail.com>"]
 license = "MIT"

--- a/sydney/enums.py
+++ b/sydney/enums.py
@@ -12,3 +12,48 @@ class ConversationStyle(Enum):
     creative = "h3relaxedimg"
     balanced = "galileo"
     precise = "h3precise"
+
+
+class ComposeTone(Enum):
+    """
+    Bing Chat compose tones. Supported options are:
+    - `professional` for formal conversations in a professional setting
+    - `casual` for informal conversations between friends or family members
+    - `enthusiastic` for conversations where the writer wants to convey excitement or passion
+    - `informational` for conversations where the writer wants to convey information or knowledge
+    - `funny` for conversations where the writer wants to be humorous or entertaining
+    """
+
+    professional = "professional"
+    casual = "casual"
+    enthusiastic = "enthusiastic"
+    informational = "informational"
+    funny = "funny"
+
+
+class ComposeFormat(Enum):
+    """
+    Bing Chat compose formats. Supported options are:
+    - `paragraph` for longer messages that are composed of multiple sentences or paragraphs
+    - `email` for messages that are structured like emails, with a clear subject line and formal greeting and closing
+    - `blogpost` for messages that are structured like blog posts, with clear headings and subheadings and a more informal tone
+    - `ideas` for messages that are used to brainstorm or share ideas
+    """
+
+    paragraph = "paragraph"
+    email = "email"
+    blogpost = "blog post"
+    ideas = "ideas"
+
+
+class ComposeLength(Enum):
+    """
+    Bing Chat compose lengths. Supported options are:
+    - `short` for messages that are only a few words or sentences long
+    - `medium` for messages that are a few paragraphs long
+    - `long` for messages that are several paragraphs or pages long
+    """
+
+    short = "short"
+    medium = "medium"
+    long = "long"


### PR DESCRIPTION
Support Compose feature from Bing Chat. Supported options are:
- `tone`
    - `professional` for formal conversations in a professional setting
    - `casual` for informal conversations between friends or family members
    - `enthusiastic` for conversations where the writer wants to convey excitement or passion
    - `informational` for conversations where the writer wants to convey information or knowledge
    - `funny` for conversations where the writer wants to be humorous or entertaining
- `format`
 - `paragraph` for longer messages that are composed of multiple sentences or paragraphs
    - `email` for messages that are structured like emails, with a clear subject line and formal greeting and closing
    - `blogpost` for messages that are structured like blog posts, with clear headings and subheadings and a more informal tone
    - `ideas` for messages that are used to brainstorm or share ideas
- `length`
    - `short` for messages that are only a few words or sentences long
    - `medium` for messages that are a few paragraphs long
    - `long` for messages that are several paragraphs or pages long