### PR TITLE
Split headers for better compatibility

### DIFF
--- a/sydney/constants.py
+++ b/sydney/constants.py
@@ -1,23 +1,6 @@
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36 Edg/117.0.2045.60"
 
-CHAT_HEADERS = {
-    "Accept": "application/json",
-    "Accept-Encoding": "gzip, deflate",
-    "Accept-Language": "en-US,en;q=0.9",
-    "Content-Type": "application/json",
-    "Origin": "https://www.bing.com",
-    "Referer": "https://www.bing.com/",
-    "Sec-Ch-Ua": '"Microsoft Edge";v="117", "Not;A=Brand";v="8", "Chromium";v="118"',
-    "Sec-Ch-Ua-Mobile": "?0",
-    "Sec-Ch-Ua-Platform": "Windows",
-    "Sec-Fetch-Dest": "empty",
-    "Sec-Fetch-Mode": "cors",
-    "Sec-Fetch-Site": "same-site",
-    "User-Agent": USER_AGENT,
-}
-
 CREATE_HEADERS = {
-    "Authority": "www.bing.com",
     "Accept": "application/json",
     "Accept-Language": "en-US,en;q=0.9",
     "Referer": "https://www.bing.com/copilot",
@@ -36,13 +19,9 @@ CHATHUB_HEADERS = {
     "Origin": "https://www.bing.com",
     "Accept-Language": "en-US,en;q=0.9",
     "User-Agent": USER_AGENT,
-    "Upgrade": "websocket",
     "Cache-Control": "no-cache",
     "Connection": "Upgrade",
-    "Sec-WebSocket-Version": "13",
-    "Sec-WebSocket-Extensions": "permessage-deflate; client_max_window_bits",
 }
-
 
 KBLOB_HEADERS = {
     "Accept-Language": "en-US,en;q=0.5",

--- a/sydney/constants.py
+++ b/sydney/constants.py
@@ -16,6 +16,36 @@ CHAT_HEADERS = {
     "User-Agent": USER_AGENT,
 }
 
+CREATE_HEADERS = {
+    "Authority": "www.bing.com",
+    "Accept": "application/json",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Referer": "https://www.bing.com/copilot",
+    "Sec-Ch-Ua": '"Microsoft Edge";v="117", "Chromium";v="118", "Not?A_Brand";v="8"',
+    "Sec-Ch-Ua-Mobile": "?0",
+    "Sec-Ch-Ua-Platform": "Windows",
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-origin",
+    "Sec-Ms-Gec": "0D3C55EA3A4602964E5474BD9C1D472632FD8E3280D266A5C761A0C6CD4C7595",
+    "Sec-Ms-Gec-Version": "1-119.0.2151.58",
+    "User-Agent": USER_AGENT,
+    "X-Edge-Shopping-Flag": "0",
+}
+
+CHATHUB_HEADERS = {
+    "Pragma": "no-cache",
+    "Origin": "https://www.bing.com",
+    "Accept-Language": "en-US,en;q=0.9",
+    "User-Agent": USER_AGENT,
+    "Upgrade": "websocket",
+    "Cache-Control": "no-cache",
+    "Connection": "Upgrade",
+    "Sec-WebSocket-Version": "13",
+    "Sec-WebSocket-Extensions": "permessage-deflate; client_max_window_bits",
+}
+
+
 KBLOB_HEADERS = {
     "Accept-Language": "en-US,en;q=0.5",
     "Content-Type": "multipart/form-data",

--- a/sydney/constants.py
+++ b/sydney/constants.py
@@ -27,8 +27,6 @@ CREATE_HEADERS = {
     "Sec-Fetch-Dest": "empty",
     "Sec-Fetch-Mode": "cors",
     "Sec-Fetch-Site": "same-origin",
-    "Sec-Ms-Gec": "0D3C55EA3A4602964E5474BD9C1D472632FD8E3280D266A5C761A0C6CD4C7595",
-    "Sec-Ms-Gec-Version": "1-119.0.2151.58",
     "User-Agent": USER_AGENT,
     "X-Edge-Shopping-Flag": "0",
 }

--- a/sydney/sydney.py
+++ b/sydney/sydney.py
@@ -16,7 +16,8 @@ from sydney.constants import (
     BING_CREATE_CONVERSATION_URL,
     BING_GET_CONVERSATIONS_URL,
     BING_KBLOB_URL,
-    CHAT_HEADERS,
+    CHATHUB_HEADERS,
+    CREATE_HEADERS,
     DELIMETER,
     KBLOB_HEADERS,
 )
@@ -56,7 +57,7 @@ class SydneyClient:
         use_proxy: bool = False,
     ) -> None:
         """
-        Client for Copilot (formerly named Bing Chat), also known as Sydney. 
+        Client for Copilot (formerly named Bing Chat), also known as Sydney.
 
         Parameters
         ----------
@@ -106,7 +107,7 @@ class SydneyClient:
 
         if not self.session:
             self.session = ClientSession(
-                headers=CHAT_HEADERS,
+                headers=CREATE_HEADERS,
                 cookies=cookies,
                 trust_env=self.use_proxy,  # Use `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
                 connector=TCPConnector(verify_ssl=False)
@@ -319,7 +320,7 @@ class SydneyClient:
         # Create a websocket connection with Copilot for sending and receiving messages.
         try:
             self.wss_client = await websockets.connect(
-                bing_chathub_url, extra_headers=CHAT_HEADERS, max_size=None
+                bing_chathub_url, extra_headers=CHATHUB_HEADERS, max_size=None
             )
         except TimeoutError:
             raise ConnectionTimeoutException(


### PR DESCRIPTION
- Split headers into two groups, one for creating a conversation and the other for websocket use to improve compatibility