### PR TITLE
Fix handling of inline messages on non streaming responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://raw.githubusercontent.com/vsakkas/sydney.py/master/images/logo.svg" width="28px" /> Sydney.py
 
-[![Latest Release](https://img.shields.io/github/v/release/vsakkas/sydney.py.svg)](https://github.com/vsakkas/sydney.py/releases/tag/v0.18.1)
+[![Latest Release](https://img.shields.io/github/v/release/vsakkas/sydney.py.svg)](https://github.com/vsakkas/sydney.py/releases/tag/v0.18.2)
 [![Python](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/vsakkas/sydney.py/blob/master/LICENSE)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sydney-py"
-version = "0.18.1"
+version = "0.18.2"
 description = "Python Client for Copilot (formerly named Bing Chat), also known as Sydney."
 authors = ["vsakkas <vasileios.sakkas96@gmail.com>"]
 license = "MIT"

--- a/sydney/sydney.py
+++ b/sydney/sydney.py
@@ -392,29 +392,30 @@ class SydneyClient:
                             raise CaptchaChallengeException("Solve CAPTCHA to continue")
                         return  # Return empty message.
 
-                    # Skip "Searching the web for..." message.
+                    # Fix index in some cases where the last message in an inline message.
+                    # Typically occurs when an attechment is provided.
+                    i = -1
                     adaptiveCards = messages[-1].get("adaptiveCards")
                     if adaptiveCards and adaptiveCards[-1]["body"][0].get("inlines"):
-                        streaming = False  # Exit, type 2 is the last message.
-                        continue
+                        i = -2  # TODO: This feel hacky
 
                     if raw:
                         yield response, None
                     else:
                         suggested_responses = None
                         # Include list of suggested user responses, if enabled.
-                        if suggestions and messages[-1].get("suggestedResponses"):
+                        if suggestions and messages[i].get("suggestedResponses"):
                             suggested_responses = [
                                 item["text"]
-                                for item in messages[-1]["suggestedResponses"]
+                                for item in messages[i]["suggestedResponses"]
                             ]
 
                         if citations:
-                            yield messages[-1]["adaptiveCards"][0]["body"][0][
+                            yield messages[i]["adaptiveCards"][0]["body"][0][
                                 "text"
                             ], suggested_responses
                         else:
-                            yield messages[-1]["text"], suggested_responses
+                            yield messages[i]["text"], suggested_responses
 
                     # Exit, type 2 is the last message.
                     streaming = False

--- a/sydney/sydney.py
+++ b/sydney/sydney.py
@@ -392,6 +392,12 @@ class SydneyClient:
                             raise CaptchaChallengeException("Solve CAPTCHA to continue")
                         return  # Return empty message.
 
+                    # Skip "Searching the web for..." message.
+                    adaptiveCards = messages[-1].get("adaptiveCards")
+                    if adaptiveCards and adaptiveCards[-1]["body"][0].get("inlines"):
+                        streaming = False  # Exit, type 2 is the last message.
+                        continue
+
                     if raw:
                         yield response, None
                     else:


### PR DESCRIPTION
- Fix handling inline messages on non streaming responses to fix potential crashes when handling type 2 responses by using the correct index if an inline message is detected