### PR TITLE
Include timestamp in arguments

### DIFF
--- a/sydney/sydney.py
+++ b/sydney/sydney.py
@@ -50,7 +50,7 @@ from sydney.exceptions import (
     NoResponseException,
     ThrottledRequestException,
 )
-from sydney.utils import as_json, check_if_url, cookies_as_dict
+from sydney.utils import as_json, check_if_url, cookies_as_dict, get_iso_timestamp
 
 
 class SydneyClient:
@@ -174,6 +174,7 @@ class SydneyClient:
                     "message": {
                         "author": "user",
                         "inputMethod": "Keyboard",
+                        "timestamp": get_iso_timestamp(),
                         "text": prompt,
                         "messageType": MessageType.CHAT.value,
                         "imageUrl": image_url,
@@ -239,6 +240,7 @@ class SydneyClient:
                     "message": {
                         "author": "user",
                         "inputMethod": "Keyboard",
+                        "timestamp": get_iso_timestamp(),
                         "text": prompt,
                         "messageType": MessageType.CHAT.value,
                     },

--- a/sydney/utils.py
+++ b/sydney/utils.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from urllib.parse import urlparse
 
 from sydney.constants import DELIMETER
@@ -26,3 +27,7 @@ def check_if_url(string: str) -> bool:
     if parsed_string.scheme and parsed_string.netloc:
         return True
     return False
+
+
+def get_iso_timestamp() -> str:
+    return datetime.now().astimezone().replace(microsecond=0).isoformat()


### PR DESCRIPTION
- Include ISO and timezone aware timestamp in arguments for improved compatibility